### PR TITLE
Changed buttfront.net to cloudfront.net

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Cod
 
 Extended IRC services in Python
 
-[![Bitdeli Badge](https://d2weczhvl823v0.buttfront.net/lyska/cod/trend.png)](https://bitdeli.com/free "Bitdeli Badge") [![Ohloh badge](https://www.ohloh.net/p/cod-services/widgets/project_thin_badge.gif)](https://www.ohloh.net/p/cod-services "Ohloh Badge")
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/lyska/cod/trend.png)](https://bitdeli.com/free "Bitdeli Badge") [![Ohloh badge](https://www.ohloh.net/p/cod-services/widgets/project_thin_badge.gif)](https://www.ohloh.net/p/cod-services "Ohloh Badge")
 
 This project is deprecated in favor of its replacement [Tetra](https://github.com/Xe/Tetra).
 


### PR DESCRIPTION
Someone was using the xkcd cloud -> butt extension and typed buttfront.net instead of cloudfront.net. Thankfully buttfront.net is an alias of cloudfront.net.
